### PR TITLE
Add a "Site Contact" email address to platform configuration settings.

### DIFF
--- a/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
+++ b/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
@@ -115,6 +115,11 @@ public class ConfigurationManager {
      * The organization that this instance of DDF is running for
      */
     public static final String ORGANIZATION = "organization";
+    
+    /**
+     * Site (email) contact
+     */
+    public static final String CONTACT = "contact";
 
     // Constants for the read-only DDF system settings
     private static final String DDF_HOME_ENVIRONMENT_VARIABLE = "DDF_HOME";

--- a/platform-configuration/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform-configuration/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -47,6 +47,8 @@
         <AD name="Version" id="version" required="true" type="String" />
 
         <AD name="Organization" id="organization" required="true" type="String" />
+
+        <AD name="Site contact" id="contact" required="true" type="String" description="The email address of the site contact" />
     </OCD>
     <Designate
             pid="ddf.platform.config">


### PR DESCRIPTION
Intended for use in Open Search Description Document generation (DDF-322), but not specific to that.
