### PR TITLE
DDF-660: Disable persistence for anonymous users

### DIFF
--- a/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
+++ b/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
@@ -38,7 +38,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PersistentStoreImpl implements PersistentStore {


### PR DESCRIPTION
This is an immediate and short-term means to disable persistence for anonymous users. The anonymous handler is currently being re-worked and this change will be replaced with an entirely new method of handling anonymous users.
