### PR TITLE
DDF-799 - removed the keystore and truststore settings from the platform...

### DIFF
--- a/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
+++ b/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
@@ -131,6 +131,14 @@ public class ConfigurationManager {
     private static final String PAX_WEB_SERVICE_PID = "org.ops4j.pax.web";
 
     private static final String JETTY_HTTP_PORT = "org.osgi.service.http.port";
+    
+    private static final String SSL_KEYSTORE_JAVA_PROPERTY = "javax.net.ssl.keyStore";
+    
+    private static final String SSL_KEYSTORE_PASSWORD_JAVA_PROPERTY = "javax.net.ssl.keyStorePassword";
+    
+    private static final String SSL_TRUSTSTORE_JAVA_PROPERTY = "javax.net.ssl.trustStore";
+    
+    private static final String SSL_TRUSTSTORE_PASSWORD_JAVA_PROPERTY = "javax.net.ssl.trustStorePassword";
 
     /**
      * List of DdfManagedServices to push the DDF system settings to.
@@ -177,6 +185,14 @@ public class ConfigurationManager {
                 .put(HTTP_PORT, getConfigurationValue(PAX_WEB_SERVICE_PID, JETTY_HTTP_PORT));
         readOnlySettings.put(SERVICES_CONTEXT_ROOT,
                 getConfigurationValue(CXF_SERVICE_PID, CXF_SERVLET_CONTEXT));
+        
+        readOnlySettings.put(KEY_STORE, System.getProperty(SSL_KEYSTORE_JAVA_PROPERTY));
+        readOnlySettings.put(KEY_STORE_PASSWORD,
+                System.getProperty(SSL_KEYSTORE_PASSWORD_JAVA_PROPERTY));
+        readOnlySettings.put(TRUST_STORE, System.getProperty(SSL_TRUSTSTORE_JAVA_PROPERTY));
+        readOnlySettings.put(TRUST_STORE_PASSWORD,
+                System.getProperty(SSL_TRUSTSTORE_PASSWORD_JAVA_PROPERTY));
+        
 
         this.configuration = new HashMap<String, String>();
 

--- a/platform-configuration/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform-configuration/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -30,18 +30,6 @@
 
         <AD name="Port" id="port" required="true" type="String" description="The port used to advertise the system. Possibilities include the port of a single node of that of a load balancer in a multi-node deployment. NOTE: Does not change the port the system runs on." />
 
-        <AD name="Trust Store:" id="trustStore" description="Trust Store location. Path is relative to ddf.home - for default (development-only) trust store, use etc/keystores/serverTruststore.jks." required="false" type="String">
-        </AD>
-
-        <AD name="Trust Store Password:" id="trustStorePassword" description="Trust Store password" required="false" type="Password">
-        </AD>
-
-        <AD name="Key Store:" id="keyStore" description="Key Store location. Path is relative to ddf.home - for default (development-only) key store, use etc/keystores/serverKeystore.jks." required="false" type="String">
-        </AD>
-
-        <AD name="Key Store Password:" id="keyStorePassword" description="Key Store password." required="false" type="Password">
-        </AD>
-
         <AD name="Site Name" id="id" required="true" type="String" description="The unique name of this instance. This name will be provided via web services that ask for the name." />
 
         <AD name="Version" id="version" required="true" type="String" description="The version of this instance." />


### PR DESCRIPTION
... config file since they are now set in the system.properties file.  Still support using the ConfigurationWatcher to retrieve these values.

This should be merged with https://github.com/codice/ddf/pull/13

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/21)

<!-- Reviewable:end -->
