### PR TITLE
DDF-1194 Adding a utility class for exceptions

### DIFF
--- a/util/src/main/java/org/codice/ddf/platform/util/Exceptions.java
+++ b/util/src/main/java/org/codice/ddf/platform/util/Exceptions.java
@@ -27,8 +27,8 @@ public final class Exceptions {
     /**
      * Given a throwable, this traces back through the causes to construct a full message.
      *
-     * @param th
-     * @return
+     * @param   th  meant to be a nested throwable, but doesn't have to be
+     * @return      all messages in reverse order (i.e. root cause message is first!)
      */
     public static String getFullMessage(Throwable th) {
         StringBuilder message = new StringBuilder(th.getMessage());

--- a/util/src/main/java/org/codice/ddf/platform/util/Exceptions.java
+++ b/util/src/main/java/org/codice/ddf/platform/util/Exceptions.java
@@ -1,0 +1,27 @@
+package org.codice.ddf.platform.util;
+
+/**
+ * This utility class defines methods useful to perform on throwable or exception objects.
+ */
+public final class Exceptions {
+
+    private Exceptions() {
+        // as a utility this should never be constructed, hence it's private
+    }
+
+    /**
+     * Given a throwable, this traces back through the causes to construct a full message.
+     *
+     * @param th
+     * @return
+     */
+    public static String getFullMessage(Throwable th) {
+        StringBuilder message = new StringBuilder(th.getMessage());
+        th = th.getCause();
+        while (th != null) {
+            message.insert(0, th.getMessage() + "\n");
+            th = th.getCause();
+        }
+        return message.toString();
+    }
+}

--- a/util/src/main/java/org/codice/ddf/platform/util/Exceptions.java
+++ b/util/src/main/java/org/codice/ddf/platform/util/Exceptions.java
@@ -1,7 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
 package org.codice.ddf.platform.util;
 
 /**
  * This utility class defines methods useful to perform on throwable or exception objects.
+ *
  */
 public final class Exceptions {
 


### PR DESCRIPTION
 - Added a utility class for exceptions
  - Added method to get the full messsage of a throwable by tracing back through the causes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/46)
<!-- Reviewable:end -->
