### PR TITLE
DDF-1196 Improved performance of security

### DIFF
--- a/security/core/security-core-impl/src/main/java/ddf/security/service/impl/AbstractAuthorizingRealm.java
+++ b/security/core/security-core-impl/src/main/java/ddf/security/service/impl/AbstractAuthorizingRealm.java
@@ -21,6 +21,7 @@ import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.cache.MemoryConstrainedCacheManager;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.opensaml.saml2.core.Attribute;
@@ -46,6 +47,10 @@ public abstract class AbstractAuthorizingRealm extends AuthorizingRealm {
     private static final String SAML_ROLE = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
 
     private List<Expansion> expansionServiceList;
+
+    public AbstractAuthorizingRealm() {
+        this.setCacheManager(new MemoryConstrainedCacheManager());
+    }
 
     /**
      * Takes the security attributes about the subject of the incoming security token and builds

--- a/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
+++ b/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
@@ -105,11 +105,24 @@ public class LoginFilter implements Filter {
 
     private Crypto signatureCrypto;
 
-    private DocumentBuilder docBuilder;
-
     private Validator assertionValidator = new SamlAssertionValidator();
 
     private final Object lock = new Object();
+
+    private static final ThreadLocal<DocumentBuilder> BUILDER =
+            new ThreadLocal<DocumentBuilder>() {
+                @Override
+                protected DocumentBuilder initialValue() {
+                    try {
+                        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                        factory.setNamespaceAware(true);
+                        return factory.newDocumentBuilder();
+                    } catch (ParserConfigurationException ex) {
+                        // This exception should not happen
+                        throw new IllegalArgumentException("Unable to create new DocumentBuilder", ex);
+                    }
+                }
+            };
 
     /**
      * Default expiration value is 31 minutes
@@ -123,14 +136,6 @@ public class LoginFilter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         LOGGER.debug("Starting LoginFilter.");
-        DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
-        docBuilderFactory.setNamespaceAware(true);
-        try {
-            docBuilder = docBuilderFactory.newDocumentBuilder();
-        } catch (ParserConfigurationException e) {
-            LOGGER.error("Unable to create doc builder.", e);
-        }
-
     }
 
     /**
@@ -253,11 +258,8 @@ public class LoginFilter implements Filter {
                             createStatus(SAMLProtocolResponseValidator.SAML2_STATUSCODE_SUCCESS,
                                     null));
 
-                    if (docBuilder == null) {
-                        throw new SecurityServiceException("Unable to validate SAML assertions.");
-                    }
-
-                    Document doc = docBuilder.newDocument();
+                    BUILDER.get().reset();
+                    Document doc = BUILDER.get().newDocument();
                     Element policyElement = OpenSAMLUtil.toDom(samlResponse, doc);
                     doc.appendChild(policyElement);
 
@@ -552,6 +554,7 @@ public class LoginFilter implements Filter {
     @Override
     public void destroy() {
         LOGGER.info("Destroying log in filter");
+        BUILDER.remove();
     }
 
     public SecurityManager getSecurityManager() {

--- a/security/interceptor/security-interceptor-anonymous/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/security/interceptor/security-interceptor-anonymous/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,7 +22,8 @@
     <reference id="contextPolicyManager" interface="org.codice.ddf.security.policy.context.ContextPolicyManager" availability="optional" />
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
 
-    <bean id="anonymousInterceptor" class="org.codice.ddf.security.interceptor.AnonymousInterceptor">
+    <bean id="anonymousInterceptor" class="org.codice.ddf.security.interceptor.AnonymousInterceptor"
+          destroy-method="destroy">
         <argument ref="securityManager" />
         <argument ref="contextPolicyManager" />
         <cm:managed-properties persistent-id="org.codice.ddf.security.interceptor.AnonymousInterceptor" update-strategy="container-managed"/>


### PR DESCRIPTION
- The anonymous interceptor now caches and reuses the subject until
  the token is about to expire.
- Using a thread local document builder to reduce overhead of always
  creating new instances of document builders and their factories.
- Set a cache manager for abstract authorizing realm to reduce info
  logging that a cache manager was not set for all secured requests.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/47)
<!-- Reviewable:end -->
