### PR TITLE
DDF-1197 created an HTTP to HTTPS proxy to use for legacy clients

### DIFF
--- a/platform-app/src/main/resources/features.xml
+++ b/platform-app/src/main/resources/features.xml
@@ -845,4 +845,9 @@
         <bundle>mvn:ddf.platform.security/platform-security-session/${project.version}</bundle>
     </feature>
 
+    <feature name="platform-http-proxy" install="manual" version="${project.version}" description="HTTP to HTTPS proxy.">
+        <feature>camel-jetty</feature>
+        <bundle>mvn:ddf.platform/platform-http-proxy/${project.version}</bundle>
+    </feature>
+
 </features>

--- a/platform-http-proxy/pom.xml
+++ b/platform-http-proxy/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>platform</artifactId>
+        <groupId>ddf.platform</groupId>
+        <version>2.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>bundle</packaging>
+    <artifactId>platform-http-proxy</artifactId>
+    <name>DDF :: Platform :: HTTP to HTTPS proxy</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.httpproxy</groupId>
+            <artifactId>proxy-camel-route</artifactId>
+            <version>${ddf.httpproxy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-configuration</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.httpproxy</groupId>
+            <artifactId>proxy-camel-servlet</artifactId>
+            <version>${ddf.httpproxy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-osgi</artifactId>
+            <version>2.14.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http</artifactId>
+            <version>2.14.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            proxy-camel-route,
+                            proxy-camel-servlet,
+                            camel-core-osgi,
+                            camel-http
+                        </Embed-Dependency>
+                        <Export-Package />
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform-http-proxy/src/main/java/org/codice/ddf/platform/http/proxy/HttpProxy.java
+++ b/platform-http-proxy/src/main/java/org/codice/ddf/platform/http/proxy/HttpProxy.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+package org.codice.ddf.platform.http.proxy;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Properties;
+
+import org.apache.commons.lang.StringUtils;
+import org.codice.proxy.http.HttpProxyService;
+import org.codice.proxy.http.HttpProxyServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpProxy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpProxy.class);
+
+    public static final String KARAF_HOME = "karaf.home";
+
+    public static final String PAX_CONFIG = "org.ops4j.pax.web.cfg";
+
+    public static final String CONFIG_DIR = "etc";
+
+    public static final String SECURE_PORT_PROPERTY = "org.osgi.service.http.port.secure";
+
+    public static final String PORT_PROPERTY = "org.osgi.service.http.port";
+
+    public static final String SECURE_ENABLED_PROPERTY = "org.osgi.service.http.secure.enabled";
+
+    public static final String HTTP_ENABLED_PROPERTY = "org.osgi.service.http.enabled";
+
+    private final HttpProxyService httpProxyService;
+
+    private String endpointName;
+
+    private String hostname;
+
+    /**
+     * Constructor
+     * @param httpProxyService - proxy service to use to start a camel proxy
+     */
+    public HttpProxy(HttpProxyService httpProxyService) {
+        this.httpProxyService = httpProxyService;
+    }
+
+    /**
+     * Starts the HTTP -> HTTPS proxy
+     */
+    public void startProxy() throws Exception {
+        Properties properties = getProperties();
+        stopProxy();
+
+        boolean isSecureEnabled = Boolean
+                .valueOf(properties.getProperty(SECURE_ENABLED_PROPERTY));
+        boolean isHttpEnabled = Boolean.valueOf(properties.getProperty(HTTP_ENABLED_PROPERTY));
+        if (isSecureEnabled && !isHttpEnabled) {
+            String httpPort = properties.getProperty(PORT_PROPERTY);
+            String httpsPort = properties.getProperty(SECURE_PORT_PROPERTY);
+            String host;
+            try {
+                host = StringUtils.isNotBlank(hostname) ?
+                        hostname :
+                        InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException e) {
+                LOGGER.warn("Unable to determine hostname, using localhost instead.", e);
+                host = "localhost";
+            }
+            endpointName = ((HttpProxyServiceImpl) httpProxyService)
+                    .start("0.0.0.0:" + httpPort, "https://" + host + ":" + httpsPort, 1000, true);
+        }
+    }
+
+    /**
+     * Returns the pax web properties.
+     * @return Properties - contains pax web properties
+     */
+    Properties getProperties() {
+        File paxConfig = new File(
+                System.getProperty(KARAF_HOME) + File.separator + CONFIG_DIR + File.separator
+                        + PAX_CONFIG);
+        Properties properties = new Properties();
+        if (paxConfig.exists()) {
+            try {
+                properties.load(new FileReader(paxConfig));
+            } catch (IOException e) {
+                LOGGER.error("Error reading file {}, not starting proxy.", PAX_CONFIG, e);
+            }
+        }
+        return properties;
+    }
+
+    /**
+     * Stops the HTTP -> HTTPS proxy
+     */
+    public void stopProxy() throws Exception {
+        if (endpointName != null) {
+            httpProxyService.stop(endpointName);
+        }
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+}

--- a/platform-http-proxy/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform-http-proxy/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint" id="proxyCamelContext" />
+
+    <bean id="httpProxyService" class="org.codice.proxy.http.HttpProxyServiceImpl" destroy-method="destroy">
+        <argument ref="blueprintBundleContext"/>
+        <argument ref="proxyCamelContext" />
+        <argument value="jetty:http" />
+    </bean>
+
+    <bean id="platformHttpProxy" class="org.codice.ddf.platform.http.proxy.HttpProxy" init-method="startProxy" destroy-method="stopProxy">
+        <cm:managed-properties persistent-id="org.codice.ddf.platform.http.proxy.HttpProxy"
+                               update-strategy="container-managed" />
+        <argument ref="httpProxyService" />
+    </bean>
+
+</blueprint>

--- a/platform-http-proxy/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform-http-proxy/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD description="HTTP to HTTPS Proxy Settings"
+         name="HTTP to HTTPS Proxy Settings"
+         id="org.codice.ddf.platform.http.proxy.HttpProxy">
+        <AD description="Hostname to use for HTTPS connection in the proxy."
+            name="Hostname" id="hostname" required="true"
+            type="String" default=""/>
+    </OCD>
+
+    <Designate pid="org.codice.ddf.platform.http.proxy.HttpProxy">
+        <Object ocdref="org.codice.ddf.platform.http.proxy.HttpProxy" />
+    </Designate>
+
+</metatype:MetaData>

--- a/platform-http-proxy/src/test/java/org/codice/ddf/platform/http/proxy/TestHttpProxy.java
+++ b/platform-http-proxy/src/test/java/org/codice/ddf/platform/http/proxy/TestHttpProxy.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+package org.codice.ddf.platform.http.proxy;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.codice.proxy.http.HttpProxyService;
+import org.codice.proxy.http.HttpProxyServiceImpl;
+import org.junit.Test;
+
+public class TestHttpProxy {
+
+    @Test
+    public void testStartingAndStoppingProxyWithDifferentConfigurations() throws Exception {
+        HttpProxyServiceImpl httpProxyService = mock(HttpProxyServiceImpl.class);
+        when(httpProxyService.start(eq("0.0.0.0:8181"), anyString(), eq(1000), eq(true)))
+                .thenReturn("endpointName");
+        HttpProxy httpProxy = new HttpProxy(httpProxyService) {
+            public Properties getProperties() {
+                Properties properties = new Properties();
+                InputStream propertiesStream = HttpProxy.class.getResourceAsStream("/etc/org.ops4j.pax.web.cfg");
+                try {
+                    properties.load(propertiesStream);
+                } catch (IOException e) {
+                    fail(e.getMessage());
+                }
+                return properties;
+            }
+        };
+        httpProxy.startProxy();
+        verify(httpProxyService, times(1)).start(eq("0.0.0.0:8181"), anyString(), eq(1000),
+                eq(true));
+
+        httpProxy.stopProxy();
+        verify(httpProxyService, times(1)).stop("endpointName");
+
+        httpProxy.setHostname("blah");
+
+        httpProxy.startProxy();
+        verify(httpProxyService, times(1)).start(eq("0.0.0.0:8181"), eq("https://blah:8993"), eq(1000), eq(true));
+
+        httpProxy.startProxy();
+        verify(httpProxyService, times(3)).stop("endpointName");
+
+        httpProxy = new HttpProxy(httpProxyService) {
+            public Properties getProperties() {
+                Properties properties = new Properties();
+                InputStream propertiesStream = HttpProxy.class.getResourceAsStream("/etc/org.ops4j.pax.web.cfg");
+                try {
+                    properties.load(propertiesStream);
+                } catch (IOException e) {
+                    fail(e.getMessage());
+                }
+                properties.put("org.osgi.service.http.enabled", "true");
+                return properties;
+            }
+        };
+        httpProxy.startProxy();
+        verify(httpProxyService, times(3)).start(eq("0.0.0.0:8181"), anyString(), eq(1000), eq(true));
+    }
+
+    @Test
+    public void testStartingWithNoProperties() throws Exception {
+        HttpProxyServiceImpl httpProxyService = mock(HttpProxyServiceImpl.class);
+        when(httpProxyService.start(anyString(), anyString(), anyInt(), anyBoolean()))
+                .thenReturn("endpointName");
+        HttpProxy httpProxy = new HttpProxy(httpProxyService) {
+            public Properties getProperties() {
+                return new Properties();
+            }
+        };
+        httpProxy.startProxy();
+        verify(httpProxyService, times(0)).start(anyString(), anyString(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    public void testLoadProperties() {
+        HttpProxyService httpProxyService = mock(HttpProxyService.class);
+        HttpProxy httpProxy = new HttpProxy(httpProxyService);
+        Properties properties = httpProxy.getProperties();
+        assertThat(0, is(properties.stringPropertyNames().size()));
+    }
+}

--- a/platform-http-proxy/src/test/resources/etc/org.ops4j.pax.web.cfg
+++ b/platform-http-proxy/src/test/resources/etc/org.ops4j.pax.web.cfg
@@ -1,0 +1,40 @@
+######################
+# HTTP settings
+######################
+
+# Enable HTTP
+org.osgi.service.http.enabled=false
+
+# Default port for the OSGI HTTP Service
+org.osgi.service.http.port=8181
+
+######################
+# HTTPS settings
+######################
+
+# Enable HTTPS
+org.osgi.service.http.secure.enabled=true
+
+# HTTPS port number
+# (Verify this port does not conflict with any other secure ports being used in your
+# network. For example, JBoss and other application servers use port 8443 by default)
+
+org.osgi.service.http.port.secure=8993
+
+# They keystore and passwords pull from the Java System Properties which are set
+# in the system.properties file.  It is recommended that the keystore values are changed
+# in that file if there are updates to the location or password of the keystore.
+# Fully-qualified path to your SSL keystore
+org.ops4j.pax.web.ssl.keystore=${javax.net.ssl.keyStore}
+
+# SSL Keystore Type
+org.ops4j.pax.web.ssl.keystore.type=${javax.net.ssl.keyStoreType}
+
+# Keystore Integrity Password
+org.ops4j.pax.web.ssl.password=${javax.net.ssl.keyStorePassword}
+
+# Keystore Password
+org.ops4j.pax.web.ssl.keypassword=${javax.net.ssl.keyStorePassword}
+
+# Client authenticate at server is wanted
+org.ops4j.pax.web.ssl.clientauthwanted=true

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <tika.version>1.7</tika.version>
         <cas.client.version>3.1.10</cas.client.version>
         <cas.client.bundle.version>${cas.client.version}_1</cas.client.bundle.version>
+        <ddf.httpproxy.version>1.0.3-SNAPSHOT</ddf.httpproxy.version>
     </properties>
 
     <distributionManagement>
@@ -338,6 +339,7 @@
         <module>util</module>
         <module>platform-filter-delegate</module>
         <module>error</module>
+        <module>platform-http-proxy</module>
         <module>platform-app</module>
         <module>docs</module>
     </modules>


### PR DESCRIPTION
 - added new HTTP to HTTPS camel proxy service
 - added integration test for anonymous SOAP HTTP access
 - disabled HTTP in pax web configuration file

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/48)
<!-- Reviewable:end -->
