### PR TITLE
DDF-1249: Include Documentation in DDF 2.8 Distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <groupId>ddf.platform</groupId>


### PR DESCRIPTION
Changed parent reference to 3.0.3-SNAPSHOT, which generates the documentation as part of the default build.

This PR is part of https://github.com/codice/ddf/pull/57

@ricklarsen @pklinef @brianfelix 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/64)
<!-- Reviewable:end -->
