### PR TITLE
DDF-1296 validators were not setting principal on validate target object which is used for onBehalfOf elements and fixed copy/paste error in metatype for PKI validator

### DIFF
--- a/security/sts/security-sts-anonymousvalidator/src/main/java/org/codice/ddf/security/validator/anonymous/AnonymousValidator.java
+++ b/security/sts/security-sts-anonymousvalidator/src/main/java/org/codice/ddf/security/validator/anonymous/AnonymousValidator.java
@@ -95,10 +95,12 @@ public class AnonymousValidator implements TokenValidator {
                 if (supportedRealm.contains(anonToken.getRealm()) && anonToken.getCredentials()
                         .equals(AnonymousAuthenticationToken.ANONYMOUS_CREDENTIALS)) {
                     validateTarget.setState(ReceivedToken.STATE.VALID);
+                    validateTarget.setPrincipal(new CustomTokenPrincipal(AnonymousAuthenticationToken.ANONYMOUS_CREDENTIALS));
                 }
             } else if (anonToken.getCredentials()
                     .equals(AnonymousAuthenticationToken.ANONYMOUS_CREDENTIALS)) {
                 validateTarget.setState(ReceivedToken.STATE.VALID);
+                validateTarget.setPrincipal(new CustomTokenPrincipal(AnonymousAuthenticationToken.ANONYMOUS_CREDENTIALS));
             }
         }
         return response;

--- a/security/sts/security-sts-pkivalidator/src/main/java/org/codice/ddf/security/validator/pki/PKITokenValidator.java
+++ b/security/sts/security-sts-pkivalidator/src/main/java/org/codice/ddf/security/validator/pki/PKITokenValidator.java
@@ -219,6 +219,7 @@ public class PKITokenValidator implements TokenValidator {
             Credential returnedCredential = validator.validate(credential, requestData);
             response.setPrincipal(
                     returnedCredential.getCertificates()[0].getSubjectX500Principal());
+            validateTarget.setPrincipal(returnedCredential.getCertificates()[0].getSubjectX500Principal());
             validateTarget.setState(STATE.VALID);
         } catch (WSSecurityException ex) {
             LOGGER.warn("Unable to validate credentials.", ex);

--- a/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,7 +38,7 @@
 
     <bean id="pkiTokenValidator"
           class="org.codice.ddf.security.validator.pki.PKITokenValidator" init-method="init">
-        <cm:managed-properties persistent-id="org.codice.ddf.security.validator.pki"/>
+        <cm:managed-properties persistent-id="org.codice.ddf.security.validator.pki" update-strategy="container-managed"/>
         <property name="signaturePropertiesPath"
                   value="${ddf.home}/etc/ws-security/server/signature.properties"/>
         <property name="realms">

--- a/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
 	<OCD description="STS PKI Token Validator Configuration."
          name="Security STS PKI Token Validator" id="org.codice.ddf.security.validator.pki">
 
-	    <AD name="Realms" id="url" required="true" type="String" cardinality="100"
+	    <AD name="Realms" id="realms" required="true" type="String" cardinality="100"
             default="karaf"
             description="The realms to be validated by this validator.">
 	    </AD>

--- a/security/sts/security-sts-upbstvalidator/src/main/java/org/codice/ddf/security/validator/uname/UPBSTValidator.java
+++ b/security/sts/security-sts-upbstvalidator/src/main/java/org/codice/ddf/security/validator/uname/UPBSTValidator.java
@@ -340,6 +340,7 @@ public class UPBSTValidator implements TokenValidator {
 
             response.setPrincipal(principal);
             response.setTokenRealm(tokenRealm);
+            validateTarget.setPrincipal(principal);
         } catch (WSSecurityException ex) {
             LOGGER.warn("", ex);
         }

--- a/security/sts/security-sts-usernametokenvalidator/src/main/java/org/codice/ddf/security/validator/username/UsernameTokenValidator.java
+++ b/security/sts/security-sts-usernametokenvalidator/src/main/java/org/codice/ddf/security/validator/username/UsernameTokenValidator.java
@@ -281,6 +281,7 @@ public class UsernameTokenValidator implements TokenValidator {
             response.setPrincipal(principal);
             response.setTokenRealm(tokenRealm);
             validateTarget.setState(ReceivedToken.STATE.VALID);
+            validateTarget.setPrincipal(principal);
         } catch (WSSecurityException ex) {
             LOGGER.warn("", ex);
         }

--- a/security/sts/security-sts-x509validator/src/main/java/org/codice/ddf/security/validator/x509/X509PathTokenValidator.java
+++ b/security/sts/security-sts-x509validator/src/main/java/org/codice/ddf/security/validator/x509/X509PathTokenValidator.java
@@ -212,6 +212,7 @@ public class X509PathTokenValidator implements TokenValidator {
             response.setPrincipal(
                     returnedCredential.getCertificates()[0].getSubjectX500Principal());
             validateTarget.setState(STATE.VALID);
+            validateTarget.setPrincipal(returnedCredential.getCertificates()[0].getSubjectX500Principal());
         } catch (WSSecurityException ex) {
             LOGGER.warn("Unable to validate credentials.", ex);
         }


### PR DESCRIPTION
@mverret @shaundmorris @clockard

@clockard can hero

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/68)
<!-- Reviewable:end -->
