### PR TITLE
DDF-1335: Added exclusion for vulnerability CVE-2011-2730 and disabled vulnerability checks in docs projects

### DIFF
--- a/admin/docs/pom.xml
+++ b/admin/docs/pom.xml
@@ -26,6 +26,22 @@
     <name>DDF :: Admin :: DOCS</name>
     <build>
         <plugins>
+            <!-- Disable vulnerability checks since this project only contains documentation -->
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <failBuildOnCVSS>11</failBuildOnCVSS>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>

--- a/compression/platform-compression-exi/dependency-check-maven-config.xml
+++ b/compression/platform-compression-exi/dependency-check-maven-config.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression">
     <!--
-        CVE-2014-9389 applies to Nexus and no evidence exist that the vulnerability was caused by Nagasena.
+        CVE-2011-2730 only applies when using JSP Expression Language (EL) which is not used in DDF.
      -->
+    <suppress>
+        <cve>CVE-2011-2730</cve>
+    </suppress>
+
+    <!--
+       CVE-2014-9389 applies to Nexus and no evidence exist that the vulnerability was caused by Nagasena.
+    -->
     <suppress>
         <notes><![CDATA[
    file name: nagasena-0000.0002.0049.0.jar

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -26,6 +26,22 @@
     <name>DDF :: platform :: DOCS</name>
     <build>
         <plugins>
+            <!-- Disable vulnerability checks since this project only contains documentation -->
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <failBuildOnCVSS>11</failBuildOnCVSS>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>

--- a/security/docs/pom.xml
+++ b/security/docs/pom.xml
@@ -26,6 +26,22 @@
     <name>DDF :: Security :: DOCS</name>
     <build>
         <plugins>
+            <!-- Disable vulnerability checks since this project only contains documentation -->
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <failBuildOnCVSS>11</failBuildOnCVSS>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>

--- a/solr/platform-solr-server-standalone/dependency-check-maven-config.xml
+++ b/solr/platform-solr-server-standalone/dependency-check-maven-config.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression">
     <!--
+        CVE-2011-2730 only applies when using JSP Expression Language (EL) which is not used in DDF.
+     -->
+    <suppress>
+        <cve>CVE-2011-2730</cve>
+    </suppress>
+
+    <!--
         Suppressing vulnerabilities CVE-2013-4221 and CVE-2013-4221 as the offending jar file (org.restlet-2.1.1.jar)
         is being manually removed from the Solr War and replaced with the fixed version. These should be removed when
         Solr is updated (DDF-1110). See pom file for details.


### PR DESCRIPTION
PR to fix DDF nightly build failures.

@figliold, @andrewkfiedler please review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/79)
<!-- Reviewable:end -->
