### PR TITLE
DDF-1336 Out-of-date bundle dependency in metrics.

### DIFF
--- a/metrics/platform-metrics-ui/pom.xml
+++ b/metrics/platform-metrics-ui/pom.xml
@@ -87,7 +87,7 @@
                         <Export-Package />
                         <Import-Package>
                             *,
-                            org.codice.ddf.ui.admin.api.module;version="[1.2.0,2.0.0)"
+                            org.codice.ddf.ui.admin.api.module;version="[1.2.0,3.0.0)"
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
Because we've normalized admin's version to match the rest of platform, this bundle reference needed to be updated.

@pklinef 
@stustison 
@brendan-hofmann 
@tbatieConnexta 
@djblue 
@rzwiefel
@roelens8

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/80)
<!-- Reviewable:end -->
