### PR TITLE
DDF-1472: Backport to support SAML headers

### DIFF
--- a/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -18,16 +18,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.NewCookie;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
@@ -46,13 +41,14 @@ import ddf.security.assertion.SecurityAssertion;
  */
 public final class RestSecurity {
 
-    // SAML_COOKIE_NAME is not available in SecurityConstants 2.4.0
-    public static final String SECURITY_COOKIE_NAME = "org.codice.websso.saml.token";
+    public static final String SAML_HEADER_PREFIX = "SAML ";
+
+    public static final String SAML_HEADER_NAME = "Authorization";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RestSecurity.class);
 
     /**
-     * Parses the incoming subject for a saml assertion and sets that as a cookie on the client.
+     * Parses the incoming subject for a saml assertion and sets that as a header on the client.
      *
      * @param subject Subject containing a SAML-based security token.
      * @param client  Non-null client to set the cookie on.
@@ -61,71 +57,42 @@ public final class RestSecurity {
     public static void setSubjectOnClient(Subject subject, Client client) {
         if (client != null && subject != null && "https"
                 .equalsIgnoreCase(client.getCurrentURI().getScheme())) {
-            javax.ws.rs.core.Cookie cookie = createSamlCookie(subject, true);
-            if (cookie == null) {
-                LOGGER.debug("SAML Cookie was null. Unable to set the cookie for the client.");
+            String encodedSamlHeader = createSamlHeader(subject);
+            if (encodedSamlHeader == null) {
+                LOGGER.debug("SAML Header was null. Unable to set the header for the client.");
                 return;
             }
-            client.cookie(cookie);
+            client.header(SAML_HEADER_NAME, encodedSamlHeader);
         }
     }
 
-    /**
-     * Sets a saml cookie without requiring ssl on the underlying client. This method
-     * only exists for compatibility with legacy or misconfigured systems, and is not
-     * recommended for use otherwise.
-     *
-     * @see #setSubjectOnClient(ddf.security.Subject, org.apache.cxf.jaxrs.client.Client)
-     */
-    public static void setUnsecuredSubjectOnClient(Subject subject, Client client) {
-        if (client != null && subject != null) {
-            javax.ws.rs.core.Cookie cookie = createSamlCookie(subject, false);
-            if (cookie == null) {
-                LOGGER.debug("SAML Cookie was null. Unable to set the cookie for the client.");
-                return;
-            }
-            client.cookie(cookie);
-        }
-    }
 
-    /**
-     * Creates a cookie to be returned to the browser if the token was successfully exchanged for
-     * a SAML assertion.
+     /**
+     * Creates an authorization header to be returned to the browser if the token was successfully
+     * exchanged for a SAML assertion
      *
-     * @param subject - {@link ddf.security.Subject} to create the cookie from
-     * @param secure  - whether or not to require SSL for this cookie
+     * @param subject - {@link ddf.security.Subject} to create the header from
      */
-    private static Cookie createSamlCookie(Subject subject, boolean secure) {
-        Cookie cookie = null;
+    private static String createSamlHeader(Subject subject) {
+        String encodedSamlHeader = null;
         org.w3c.dom.Element samlToken = null;
-        Date expires = null;
         try {
             for (Object principal : subject.getPrincipals().asList()) {
                 if (principal instanceof SecurityAssertion) {
                     SecurityToken securityToken = ((SecurityAssertion) principal)
                             .getSecurityToken();
                     samlToken = securityToken.getToken();
-                    expires = securityToken.getExpires();
                 }
             }
             if (samlToken != null) {
-                BigDecimal maxAge = null;
-                if (expires == null) {
-                    //default to 10 minutes
-                    maxAge = new BigDecimal(600);
-                } else {
-                    maxAge = new BigDecimal((expires.getTime() - new Date().getTime()) / 1000);
-                }
                 SamlAssertionWrapper assertion = new SamlAssertionWrapper(samlToken);
                 String saml = assertion.assertionToString();
-                cookie = new NewCookie(new Cookie(SECURITY_COOKIE_NAME, encodeSaml(saml)), "",
-                        // gives us a checked exception for the cast
-                        maxAge.intValueExact(), secure).toCookie();
+                encodedSamlHeader = SAML_HEADER_PREFIX + encodeSaml(saml);
             }
         } catch (WSSecurityException | ArithmeticException e) {
             LOGGER.error("Unable to parse SAML assertion from subject.", e);
         }
-        return cookie;
+        return encodedSamlHeader;
     }
 
     /**

--- a/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -96,7 +96,7 @@ public final class RestSecurity {
     }
 
     /**
-     * Encodes the SAML assertion as a deflated Base64 String so that it can be used as a Cookie.
+     * Encodes the SAML assertion as a deflated Base64 String so that it can be used as a Header.
      *
      * @param token SAML assertion as a token
      * @return String

--- a/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
+++ b/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
@@ -84,11 +84,11 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("https://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNotNull(client.getHeaders().get("Cookie"));
-        ArrayList cookies = (ArrayList) client.getHeaders().get("Cookie");
+        assertNotNull(client.getHeaders().get(RestSecurity.SAML_HEADER_NAME));
+        ArrayList headers = (ArrayList) client.getHeaders().get(RestSecurity.SAML_HEADER_NAME);
         boolean containsSaml = false;
-        for (Object cookie : cookies) {
-            if (StringUtils.contains(cookie.toString(), RestSecurity.SECURITY_COOKIE_NAME)) {
+        for (Object header : headers) {
+            if (StringUtils.contains(header.toString(), RestSecurity.SAML_HEADER_PREFIX)) {
                 containsSaml = true;
             }
         }
@@ -106,7 +106,7 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("http://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNull(client.getHeaders().get("Cookie"));
+        assertNull(client.getHeaders().get(RestSecurity.SAML_HEADER_NAME));
     }
 
     @Test

--- a/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
+++ b/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
@@ -14,8 +14,6 @@
 package org.codice.ddf.security.filter.websso;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,7 +24,6 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -222,10 +219,7 @@ public class WebSSOFilter implements Filter {
             filterChain.doFilter(httpRequest, httpResponse);
         } catch (InvalidSAMLReceivedException e) {
             // we tried to process an invalid or missing SAML assertion
-            deleteCookie(SAML_COOKIE_NAME, httpRequest, httpResponse);
-            deleteCookie(SAML_COOKIE_REF, httpRequest, httpResponse);
-            // redirect to ourselves without the SAML cookies
-            httpResponse.sendRedirect(httpRequest.getRequestURI());
+            returnSimpleResponse(HttpServletResponse.SC_UNAUTHORIZED, httpResponse);
         } catch (Exception e) {
             LOGGER.debug("Exception in filter chain - passing off to handlers. Msg: {}",
                     e.getMessage(), e);
@@ -296,24 +290,6 @@ public class WebSSOFilter implements Filter {
             response.flushBuffer();
         } catch (IOException ioe) {
             LOGGER.debug("Failed to send auth response", ioe);
-        }
-    }
-
-    public void deleteCookie(String cookieName, HttpServletRequest request,
-            HttpServletResponse response) {
-        //remove session cookie
-        try {
-            LOGGER.debug("Removing cookie {}", cookieName);
-            response.setContentType("text/html");
-            Cookie cookie = new Cookie(cookieName, "");
-            URL url = new URL(request.getRequestURL().toString());
-            cookie.setDomain(url.getHost());
-            cookie.setMaxAge(0);
-            cookie.setPath("/");
-            cookie.setComment("EXPIRING COOKIE at " + System.currentTimeMillis());
-            response.addCookie(cookie);
-        } catch (MalformedURLException e) {
-            LOGGER.warn("Unable to delete cookie {}", cookieName, e);
         }
     }
 

--- a/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
+++ b/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
@@ -13,17 +13,11 @@
  */
 package org.codice.ddf.security.handler.saml;
 
-import java.io.ByteArrayInputStream; //
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
-import java.util.zip.Inflater;
-import java.util.zip.InflaterInputStream;
 
-import javax.servlet.FilterChain; //
+import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -33,7 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.xml.stream.XMLStreamException;
 
-import org.apache.commons.codec.binary.Base64; //
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.codice.ddf.security.common.HttpUtils;
@@ -65,13 +58,6 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
 
     public SAMLAssertionHandler() {
         LOGGER.debug("Creating SAML Assertion handler.");
-    }
-
-    public static String decodeSaml(String encodedToken) throws IOException {
-        byte[] deflatedToken = Base64.decodeBase64(encodedToken);
-        InputStream is = new InflaterInputStream(new ByteArrayInputStream(deflatedToken),
-                new Inflater(false));
-        return org.apache.commons.io.IOUtils.toString(is, "UTF-8");
     }
 
     @Override
@@ -120,7 +106,7 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
         String authHeader = ((HttpServletRequest) request)
                 .getHeader(SAML_HEADER_NAME);
 
-        // check for full SAML assertions coming in via Headers (backport as per DDF-1472)
+        // check for full SAML assertions coming in via Headers
         if (authHeader != null) {
             String[] tokenizedAuthHeader = authHeader.split(" ");
             if (tokenizedAuthHeader.length != 2) {
@@ -134,7 +120,7 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
             String encodedSamlAssertion = tokenizedAuthHeader[1];
             LOGGER.trace("Header retrieved");
             try {
-                String tokenString = decodeSaml(encodedSamlAssertion);
+                String tokenString = RestSecurity.decodeSaml(encodedSamlAssertion);
                 LOGGER.trace("Header value: {}", tokenString);
                 securityToken = new SecurityToken();
                 Element thisToken = StaxUtils.read(new StringReader(tokenString))
@@ -184,8 +170,8 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
      * If an error occured during the processing of the request, this method will get called. Since
      * SAML handling is typically processed first, then we can assume that there was an error with
      * the presented SAML assertion - either it was invalid, or the reference didn't match a
-     * cached assertion, etc. In order not to get stuck in a processing loop, we will remove the
-     * existing SAML assertion cookies - that will allow handling to progress moving forward.
+     * cached assertion, etc. In order not to get stuck in a processing loop, we will return a 401
+     * status code.
      *
      * @param servletRequest  http servlet request
      * @param servletResponse http servlet response
@@ -194,8 +180,8 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
      * @throws ServletException
      */
     @Override
-    public HandlerResult handleError(ServletRequest servletRequest, ServletResponse servletResponse,
-                                     FilterChain chain) throws ServletException {
+    public HandlerResult handleError(ServletRequest servletRequest,
+                                     ServletResponse servletResponse, FilterChain chain) throws ServletException {
         HandlerResult result = new HandlerResult();
 
         HttpServletRequest httpRequest = servletRequest instanceof HttpServletRequest ?
@@ -208,33 +194,19 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
             return result;
         }
 
-        LOGGER.debug("In error handler for saml - clearing cookies and returning no action taken.");
+        LOGGER.debug(
+                "In error handler for saml - setting status code to 401 and returning status REDIRECTED.");
 
         // we tried to process an invalid or missing SAML assertion
-        deleteCookie(SecurityConstants.SAML_COOKIE_NAME, httpRequest, httpResponse);
-        deleteCookie(SecurityConstants.SAML_COOKIE_REF, httpRequest, httpResponse);
-
-        result.setStatus(HandlerResult.Status.NO_ACTION);
-        return result;
-    }
-
-    public void deleteCookie(String cookieName, HttpServletRequest request,
-                             HttpServletResponse response) {
-        //remove session cookie
         try {
-            LOGGER.debug("Removing cookie {}", cookieName);
-            response.setContentType("text/html");
-            Cookie cookie = new Cookie(cookieName, "");
-            URL url = null;
-            url = new URL(request.getRequestURL().toString());
-            cookie.setDomain(url.getHost());
-            cookie.setMaxAge(0);
-            cookie.setPath("/");
-            cookie.setComment("EXPIRING COOKIE at " + System.currentTimeMillis());
-            response.addCookie(cookie);
-        } catch (MalformedURLException e) {
-            LOGGER.warn("Unable to delete cookie {}", cookieName, e);
+            httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            httpResponse.flushBuffer();
+        } catch (IOException e) {
+            LOGGER.debug("Failed to send auth response", e);
         }
+        result.setStatus(HandlerResult.Status.REDIRECTED);
+        return result;
     }
 
 }

--- a/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
+++ b/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -15,11 +15,20 @@ package org.codice.ddf.security.handler.saml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.Cookie;
@@ -29,8 +38,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.apache.cxf.common.util.Base64Utility;
 import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.rs.security.saml.DeflateEncoderDecoder;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.SamlAssertionWrapper;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.codice.ddf.security.handler.api.HandlerResult;
@@ -64,11 +78,39 @@ public class SAMLAssertionHandlerTest {
     }
 
     /**
+     * Encodes the SAML assertion as a deflated Base64 String so that it can be used as a Header.
+     *
+     * @param token SAML assertion as a string
+     * @return String
+     * @throws WSSecurityException if the assertion in the token cannot be converted
+     */
+    public static String encodeSaml(String token) throws WSSecurityException {
+        ByteArrayOutputStream tokenBytes = new ByteArrayOutputStream();
+        try (OutputStream tokenStream = new DeflaterOutputStream(tokenBytes,
+                new Deflater(Deflater.DEFAULT_COMPRESSION, false))) {
+            IOUtils.copy(new ByteArrayInputStream(token.getBytes(StandardCharsets.UTF_8)),
+                    tokenStream);
+            tokenStream.close();
+
+            return new String(Base64.encodeBase64(tokenBytes.toByteArray()));
+        } catch (IOException e) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, e);
+        }
+    }
+
+    public static String decodeSaml(String encodedToken) throws IOException {
+        byte[] deflatedToken = Base64.decodeBase64(encodedToken);
+        InputStream is = new InflaterInputStream(new ByteArrayInputStream(deflatedToken),
+                new Inflater(false));
+        return org.apache.commons.io.IOUtils.toString(is, "UTF-8");
+    }
+
+    /**
      * This test ensures the proper functionality of SAMLAssertionHandler's
      * method, getNormalizedToken(), when given a valid HttpServletRequest.
      */
     @Test
-    public void testGetNormalizedTokenSuccess() throws Exception {
+    public void testGetNormalizedTokenSuccessWithCookie() throws Exception {
         SAMLAssertionHandler handler = new SAMLAssertionHandler();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -82,7 +124,7 @@ public class SAMLAssertionHandlerTest {
         String saml = wrappedAssertion.assertionToString();
         Cookie cookie = new Cookie(SecurityConstants.SAML_COOKIE_NAME,
                 RestSecurity.encodeSaml(saml));
-        when(request.getCookies()).thenReturn(new Cookie[] {cookie});
+        when(request.getCookies()).thenReturn(new Cookie[]{cookie});
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
 
@@ -95,7 +137,7 @@ public class SAMLAssertionHandlerTest {
      * method, getNormalizedToken(), when given an invalid HttpServletRequest.
      */
     @Test
-    public void testGetNormalizedTokenFailure() {
+    public void testGetNormalizedTokenFailurewithCookie() {
         SAMLAssertionHandler handler = new SAMLAssertionHandler();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -103,6 +145,53 @@ public class SAMLAssertionHandlerTest {
         FilterChain chain = mock(FilterChain.class);
 
         when(request.getCookies()).thenReturn(null);
+
+        HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
+
+        assertNotNull(result);
+        assertEquals(HandlerResult.Status.NO_ACTION, result.getStatus());
+    }
+
+    /**
+     * This test ensures the proper functionality of SAMLAssertionHandler's
+     * method, getNormalizedToken(), when given a valid HttpServletRequest.
+     */
+    @Test
+    public void testGetNormalizedTokenSuccessWithHeader() throws Exception {
+        SAMLAssertionHandler handler = new SAMLAssertionHandler();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        Element assertion = readDocument("/saml.xml").getDocumentElement();
+        String assertionId = assertion.getAttributeNodeNS(null, "ID").getNodeValue();
+        SecurityToken samlToken = new SecurityToken(assertionId, assertion, null);
+        SamlAssertionWrapper wrappedAssertion = new SamlAssertionWrapper(samlToken.getToken());
+        String saml = wrappedAssertion.assertionToString();
+
+        doReturn("SAML " + encodeSaml(saml)).when(request)
+                .getHeader(SAMLAssertionHandler.SAML_HEADER_NAME);
+
+        HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
+
+        assertNotNull(result);
+        assertEquals(HandlerResult.Status.COMPLETED, result.getStatus());
+    }
+
+    /**
+     * This test ensures the proper functionality of SAMLAssertionHandler's
+     * method, getNormalizedToken(), when given an invalid HttpServletRequest.
+     */
+    @Test
+    public void testGetNormalizedTokenFailureWithHeader() {
+        SAMLAssertionHandler handler = new SAMLAssertionHandler();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        doReturn(null).when(request).getHeader(SAMLAssertionHandler.SAML_HEADER_NAME);
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
 
@@ -119,5 +208,20 @@ public class SAMLAssertionHandlerTest {
             throws SAXException, IOException, ParserConfigurationException {
         InputStream inStream = getClass().getResourceAsStream(name);
         return readXml(inStream);
+    }
+
+    /**
+     * Encodes the SAML assertion as a deflated Base64 String so that it can be used as a Cookie.
+     *
+     * @param token
+     * @return String
+     * @throws WSSecurityException
+     */
+    private String encodeSaml(org.w3c.dom.Element token) throws WSSecurityException {
+        SamlAssertionWrapper assertion = new SamlAssertionWrapper(token);
+        String samlStr = assertion.assertionToString();
+        DeflateEncoderDecoder deflateEncoderDecoder = new DeflateEncoderDecoder();
+        byte[] deflatedToken = deflateEncoderDecoder.deflateToken(samlStr.getBytes());
+        return Base64Utility.encode(deflatedToken);
     }
 }


### PR DESCRIPTION
In order to allow user identity federation between 2.8.x and 2.7.x,
it was neccessary to add the ability to accept SAML assertions
stored in headers. 2.8.x can accept cookie-assertions, but only
sends header-assertions. Without this fix, user identity can only be
federated one-way, from 2.7.x to 2.8.x, and not the other direction.
See ticket DDF-1472.
- Updated SAMLAssertionHandler to process incoming authorization
  headers for SAML assertions
- Updated RestSecurity to use headers
- Updated unit tests to cover new header code

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-platform/96)

<!-- Reviewable:end -->
